### PR TITLE
Extract getAudioInputMediaDeviceMatch into a separate class and rework to not fetch current audio input media devices

### DIFF
--- a/src/utils/fetchMediaDevices.js
+++ b/src/utils/fetchMediaDevices.js
@@ -79,64 +79,6 @@ const fetchVideoOutputMediaDevices = async (isAggressive = true) => {
   return outputMediaDevices.filter(device => device.kind.includes("video"));
 };
 
-/**
- * Performs best-guess match of given audio input previousDeviceInfo against
- * the currently available audio input devices.
- *
- * A use case for this may be for determining a default audio device against an
- * Object which was populated from previously serialized data.
- *
- * @param {MediaDeviceInfo | Object} previousDeviceInfo A regular Object may be
- * passed if unable to acquire original MediaDeviceInfo (i.e. from a serialized
- * cache, etc.)
- * @param {boolean | Object} isAggressiveOrMockObject If boolean is given, it
- * will fetch the current audio input media devices; if an array is given, it
- * will use it for mock data.
- * @return {Promise<MediaDeviceInfo | Object | null>}
- */
-const fetchAudioInputMediaDeviceMatch = async (
-  previousDeviceInfo,
-  isAggressiveOrMockObject = true
-) => {
-  const inputMediaDevices =
-    typeof isAggressiveOrMockObject === "boolean"
-      ? await fetchAudioInputMediaDevices(isAggressive)
-      : isAggressiveOrMockObject;
-
-  if (previousDeviceInfo.deviceId) {
-    const matchedDevice = inputMediaDevices.find(
-      device => previousDeviceInfo.deviceId === device.deviceId
-    );
-
-    if (matchedDevice) {
-      return matchedDevice;
-    }
-  }
-
-  if (previousDeviceInfo.groupId) {
-    const matchedDevice = inputMediaDevices.find(
-      device => previousDeviceInfo.groupId === device.groupId
-    );
-
-    if (matchedDevice) {
-      return matchedDevice;
-    }
-  }
-
-  if (previousDeviceInfo.label) {
-    // Find first matched device based on label
-    const matchedDevice = inputMediaDevices.find(
-      device => previousDeviceInfo.label === device.label
-    );
-
-    if (matchedDevice) {
-      return matchedDevice;
-    }
-  }
-
-  return null;
-};
-
 module.exports = fetchMediaDevices;
 
 module.exports.fetchInputMediaDevices = fetchInputMediaDevices;
@@ -146,6 +88,3 @@ module.exports.fetchVideoInputMediaDevices = fetchVideoInputMediaDevices;
 module.exports.fetchOutputMediaDevices = fetchOutputMediaDevices;
 module.exports.fetchAudioOutputMediaDevices = fetchAudioOutputMediaDevices;
 module.exports.fetchVideoOutputMediaDevices = fetchVideoOutputMediaDevices;
-
-module.exports.fetchAudioInputMediaDeviceMatch =
-  fetchAudioInputMediaDeviceMatch;

--- a/src/utils/getMediaDeviceMatch.js
+++ b/src/utils/getMediaDeviceMatch.js
@@ -1,0 +1,54 @@
+/**
+ * Performs best-guess match of given audio input previousDeviceInfo against
+ * the currently available audio input devices.
+ *
+ * A use case for this may be for determining a default audio device against an
+ * Object which was populated from previously serialized data.
+ *
+ * @param {MediaDeviceInfo | Object} previousDeviceInfo A regular Object may be
+ * passed if unable to acquire original MediaDeviceInfo (i.e. from a serialized
+ * cache, etc.)
+ * @param {MediaDeviceInfo[] | Object[]} currentDevices The current list of
+ * audio input devices.
+ * @return {MediaDeviceInfo | Object | null}
+ */
+const getAudioInputMediaDeviceMatch = (previousDeviceInfo, currentDevices) => {
+  if (previousDeviceInfo.deviceId) {
+    const matchedDevice = currentDevices.find(
+      device => previousDeviceInfo.deviceId === device.deviceId
+    );
+
+    if (matchedDevice) {
+      return matchedDevice;
+    }
+  }
+
+  if (previousDeviceInfo.groupId) {
+    const matchedDevice = currentDevices.find(
+      device => previousDeviceInfo.groupId === device.groupId
+    );
+
+    if (matchedDevice) {
+      return matchedDevice;
+    }
+  }
+
+  if (previousDeviceInfo.label) {
+    // Find first matched device based on label
+    const matchedDevice = currentDevices.find(
+      device => previousDeviceInfo.label === device.label
+    );
+
+    if (matchedDevice) {
+      return matchedDevice;
+    }
+  }
+
+  return null;
+};
+
+// NOTE: This is left as a non-default export because other methods may follow,
+// one of which may match the filename
+module.exports = {
+  getAudioInputMediaDeviceMatch,
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,7 +8,7 @@ const {
   getSharedAudioContext,
   untilAudioContextResumed,
 } = require("./getAudioContext");
-// const splitMediaStream = require('./splitMediaStream')
+const getMediaDeviceMatch = require("./getMediaDeviceMatch");
 const stopMediaStream = require("./stopMediaStream");
 const getMediaStreamTrackControllerInstances = require("./getMediaStreamTrackControllerInstances");
 
@@ -21,7 +21,7 @@ module.exports = {
   getNewAudioContext,
   getSharedAudioContext,
   untilAudioContextResumed,
-  // splitMediaStream,
+  getMediaDeviceMatch,
   stopMediaStream,
   getMediaStreamTrackControllerInstances,
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -62,7 +62,7 @@ test("utils.getSharedAudioContext", t => {
   t.end();
 });
 
-test("utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch", async t => {
+test("utils.getMediaDeviceMatch.getAudioInputMediaDeviceMatch", t => {
   t.plan(7);
 
   const mockDevices = [
@@ -92,7 +92,7 @@ test("utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch", async t => {
   ];
 
   t.deepEquals(
-    await utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch(
+    utils.getMediaDeviceMatch.getAudioInputMediaDeviceMatch(
       {
         deviceId: "old-device-id",
         kind: "audioinput",
@@ -113,7 +113,7 @@ test("utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch", async t => {
   );
 
   t.deepEquals(
-    await utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch(
+    utils.getMediaDeviceMatch.getAudioInputMediaDeviceMatch(
       {
         deviceId:
           "d52f39bf56b99e78edfa08792464b41b253778c54101d1d6186cc2a3df1c5341",
@@ -132,7 +132,7 @@ test("utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch", async t => {
   );
 
   t.deepEquals(
-    await utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch(
+    utils.getMediaDeviceMatch.getAudioInputMediaDeviceMatch(
       {
         groupId:
           "9253a523d57bf06af9ce171e7ddc6befc8e4c0216f1eb8ace9d16beef14612dc",
@@ -151,7 +151,7 @@ test("utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch", async t => {
   );
 
   t.deepEquals(
-    await utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch(
+    utils.getMediaDeviceMatch.getAudioInputMediaDeviceMatch(
       {
         label: "Scarlett Solo USB Analog Stereo",
       },
@@ -169,7 +169,7 @@ test("utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch", async t => {
   );
 
   t.deepEquals(
-    await utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch(
+    utils.getMediaDeviceMatch.getAudioInputMediaDeviceMatch(
       {
         label: undefined,
       },
@@ -180,7 +180,7 @@ test("utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch", async t => {
   );
 
   t.deepEquals(
-    await utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch(
+    utils.getMediaDeviceMatch.getAudioInputMediaDeviceMatch(
       {
         label: "some-unknown-label",
       },
@@ -191,10 +191,7 @@ test("utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch", async t => {
   );
 
   t.deepEquals(
-    await utils.fetchMediaDevices.fetchAudioInputMediaDeviceMatch(
-      {},
-      mockDevices
-    ),
+    utils.getMediaDeviceMatch.getAudioInputMediaDeviceMatch({}, mockDevices),
     null,
     "no match on no previous info"
   );


### PR DESCRIPTION
Current audio input media devices are to always be supplied to the function and it is now synchronous.